### PR TITLE
Wire up refine-preview-sample IPC for the sample-based preview refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meaningfully/electron-app",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Semantic search over CSVs",
   "main": "./out/main/index.js",
   "author": "jeremybmerrill.com",
@@ -34,8 +34,8 @@
     "@llamaindex/openai": "^0.4.14",
     "@llamaindex/postgres": "^0.0.62",
     "@llamaindex/weaviate": "^0.0.34",
-    "@meaningfully/core":"^0.1.10",
-    "@meaningfully/ui": "^0.0.11",
+    "@meaningfully/core":"^0.1.12",
+    "@meaningfully/ui": "^0.0.13",
     "better-sqlite3": "^11.8.1",
     "electron-updater": "^6.1.7",
     "js-tiktoken": "^1.0.8",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -169,7 +169,20 @@ app.whenReady().then(() => {
     }
   });
 
-  ipcMain.handle('get-settings', async () => {   
+  // Re-previews a sample already fetched via generate-preview-data, under a (possibly
+  // changed) config. No file I/O -- callers should use this instead of
+  // generate-preview-data for config-only changes (chunk size, splitting, model) that don't
+  // require re-reading the source CSV.
+  ipcMain.handle('refine-preview-sample', async (_, formData: (DocumentSetParams & { sample: Array<{ text: string, metadata: Record<string, any> }>, documentCount: number })) => {
+    try {
+      return await docService.refinePreviewSample(formData);
+    } catch (error) {
+      console.error('Error refining preview sample:', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('get-settings', async () => {
     try {
       return await docService.getMaskedSettings();
     } catch (error) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -20,6 +20,11 @@ export interface EmbeddingResult {
   index?: any;
 }
 
+export interface SampleDocument {
+  text: string;
+  metadata: Record<string, any>;
+}
+
 export interface PreviewResult {
   success: boolean;
   error?: string;
@@ -30,7 +35,11 @@ export interface PreviewResult {
   estimatedPrice?: number;
   tokenCount?: number;
   pricePer1M?: number;
-} 
+  // present on generatePreviewData's response so refinePreviewSample can be called later
+  // without re-reading the source file
+  documentCount?: number;
+  sample?: SampleDocument[];
+}
 
 export interface DocumentSetMetadata {
   documentSetId: number;
@@ -76,6 +85,11 @@ export interface UploadFormData extends BaseUploadFormData {
   fileName: string;
 }
 
+export interface RefinePreviewSampleFormData extends BaseUploadFormData {
+  sample: SampleDocument[];
+  documentCount: number;
+}
+
 declare global {
   interface Window {
     electron: ElectronAPI
@@ -101,7 +115,8 @@ declare global {
       getSettings: () => Promise<Settings>, 
       setSettings: (settings: Settings) => Promise<void>,
       deleteDocumentSet: (documentSetId: number) => Promise<{ success: boolean }>,
-      generatePreviewData: (formData: UploadFormData) => Promise<{ success: boolean, nodes: Record<string, any>[], estimatedPrice: number, tokenCount: number }>,
+      generatePreviewData: (formData: UploadFormData) => Promise<PreviewResult>,
+      refinePreviewSample: (formData: RefinePreviewSampleFormData) => Promise<PreviewResult>,
       getUploadProgress: () => Promise<UploadProgress>,
       getAvailableModelOptions: () => Promise<{
         availableModelOptions: Record<string, string[]>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,10 +42,31 @@ contextBridge.exposeInMainWorld('api', {
       sploderMaxSize: number, 
       chunkSize: number,
       chunkOverlap: number,
+      modelName: string,
+      modelProvider: string,
       fileContent: string;
 
     }) => {
     return ipcRenderer.invoke('generate-preview-data', formData);
+  },
+  // Re-previews a sample already returned by generatePreviewData, under a (possibly
+  // changed) config. No file content to send -- just the small cached sample.
+  refinePreviewSample: (formData: {
+      datasetName: string,
+      description: string,
+      textColumns: string[],
+      metadataColumns: string[],
+      splitIntoSentences: boolean,
+      combineSentencesIntoChunks: boolean,
+      sploderMaxSize: number,
+      chunkSize: number,
+      chunkOverlap: number,
+      modelName: string,
+      modelProvider: string,
+      sample: Array<{ text: string; metadata: Record<string, any> }>;
+      documentCount: number;
+    }) => {
+    return ipcRenderer.invoke('refine-preview-sample', formData);
   },
   searchDocumentSet: (params: {
     documentSetId: number;


### PR DESCRIPTION
## Summary
Electron-side plumbing for jeremybmerrill/meaningfully#48. `@meaningfully/core` (jeremybmerrill/meaningfully-core#3) adds `previewSample()`/`MeaningfullyAPI#refinePreviewSample`, which lets the preview UI re-chunk a small cached sample under new config (chunk size, splitting, model) without touching the CSV again. This PR exposes that through the app:

- New `refine-preview-sample` IPC handler in `src/main/index.ts` — unlike `generate-preview-data`, it does **no file I/O**: no temp file, no base64 decode, just forwards the cached sample + config straight to `docService.refinePreviewSample`.
- Exposed as `api.refinePreviewSample` from the preload script, typed in `src/preload/index.d.ts` (added `SampleDocument`/`RefinePreviewSampleFormData`, extended `PreviewResult` with `documentCount`/`sample`).
- Tightened `generatePreviewData`'s return type to the real `PreviewResult` shape instead of a hand-rolled subset that was already missing `pricePer1M`/`error`.

## Depends on (not yet published)
- `@meaningfully/core` >= 0.1.12 — jeremybmerrill/meaningfully-core#3
- `@meaningfully/ui` >= 0.0.13 — jeremybmerrill/meaningfully-ui#3 (targets #2, which should merge first)

Bumped both dependency ranges in `package.json` to reflect what this actually needs. **`npm install` will fail against the registry until both are published** — that's expected; this PR is ready to merge once they are (may need a `package-lock.json` refresh at that point).

## Test plan
- Verified by temporarily swapping the local `meaningfully-core` build (with the new methods) into `node_modules/@meaningfully/core` and running `tsc --noEmit -p tsconfig.node.json --composite false` — passes clean against the new `refinePreviewSample` method and types. Reverted the swap before committing (package.json/package-lock.json only reference the real registry versions).
- Couldn't exercise the actual preview flow end-to-end in a running app, since that requires the published dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)