### PR TITLE
Fix flaky wdio e2e tests and the upload bug causing them

### DIFF
--- a/e2e/features/initial-application-view.feature
+++ b/e2e/features/initial-application-view.feature
@@ -18,7 +18,7 @@ Feature: Initial Application View
     # set an API key
     
     And the settings store is empty 
-    And the app is navigated to the 'Settings / API Keys' link
+    And the app is navigated to the 'Settings / API Keys' navbar link
     And the uploadCsv function has been mocked
     And the OpenAI API Key value is set on the page
     And the "Save" component has been clicked

--- a/e2e/features/search-page.feature
+++ b/e2e/features/search-page.feature
@@ -1,8 +1,9 @@
 Feature: Search page
 
-  Background: 
+  Background:
     Given the application has started
-    And the settings store is empty 
+    And the metadata store is empty
+    And the settings store is empty
     And the app is navigated to the 'Settings / API Keys' navbar link
     And the uploadCsv function has been mocked
     And the OpenAI API Key value is set on the page

--- a/e2e/step-definitions/common.steps.ts
+++ b/e2e/step-definitions/common.steps.ts
@@ -21,7 +21,16 @@ When('the {string} component has been clicked', async (componentName: string) =>
     const btn = await $(selector);
     await btn.waitForDisplayed({ timeout: 5000 });
     await btn.click();
-    await browser.pause(500);
+    if (componentName === 'Search button') {
+        // Wait for the actual async search (a real vector store query) to finish,
+        // rather than a fixed pause: the button's own text flips back once it's done.
+        await browser.waitUntil(async () => {
+            const text = await (await $(selector)).getText();
+            return !text.includes('Searching');
+        }, { timeout: 30000, interval: 250 });
+    } else {
+        await browser.pause(500);
+    }
 });
 
 
@@ -31,7 +40,19 @@ When('the {string} component has been clicked, waiting {int}', async (componentN
     const btn = await $(selector);
     await btn.waitForDisplayed({ timeout: 5000 });
     await btn.click();
-    await browser.pause(waitTime);
+    if (componentName === 'Upload button') {
+        // Wait for the actual async upload (embedding + vector store write) to finish,
+        // rather than a fixed pause: otherwise the next scenario step can start a second
+        // upload while this one is still running, and the two race on the vector store.
+        await browser.waitUntil(async () => {
+            const el = await $(selector);
+            if (!(await el.isExisting())) return true; // navigated away on success
+            const text = await el.getText();
+            return !text.includes('Uploading');
+        }, { timeout: 60000, interval: 250 });
+    } else {
+        await browser.pause(waitTime);
+    }
 });
 
 

--- a/e2e/step-definitions/initial_application_view.steps.ts
+++ b/e2e/step-definitions/initial_application_view.steps.ts
@@ -9,9 +9,12 @@ const DATASET_ROW_SELECTOR = '[data-testid="existing-spreadsheet-row"]'; // Sele
 // execSync('sqlite3  ./e2e/test-storage/metadata.db "CREATE TABLE IF NOT EXISTS meaningfully_settings (settings_id INTEGER PRIMARY KEY AUTOINCREMENT,  settings TEXT NOT NULL );" "CREATE TABLE IF NOT EXISTS document_sets ( set_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE, upload_date TEXT NOT NULL, parameters TEXT NOT NULL, total_documents INTEGER NOT NULL DEFAULT 0);"');
 
 Given("the metadata store is empty", async () => {
-    // execSync('sqlite3  ./e2e/test-storage/metadata.db "DELETE FROM document_sets"');
-    // starts empty!
-    1+1
+    await browser.execute(async () => {
+        // @ts-ignore
+        const { documents } = await window.api.listDocumentSets(1, 1000);
+        // @ts-ignore
+        await Promise.all(documents.map((d) => window.api.deleteDocumentSet(d.documentSetId)));
+    });
 });
 
 Given("the uploadCsv function has been mocked", async () => {
@@ -119,13 +122,13 @@ Given("the metadata store contains {int} entries", async (count: number) => {
 });
 
 Then("no datasets should be listed", async () => {
-    const datasets = await $$(DATASET_ROW_SELECTOR);
-    await expect(datasets).toBeElementsArrayOfSize(0);
+    // Don't await $$ before passing to expect: an already-resolved array can't be
+    // re-queried, so expect's built-in retry/polling would just recheck a stale snapshot.
+    await expect($$(DATASET_ROW_SELECTOR)).toBeElementsArrayOfSize(0);
 });
 
 Then("{int} datasets should be listed", async (expectedCount: number) => {
-    const datasets = await $$(DATASET_ROW_SELECTOR);
-    await expect(datasets).toBeElementsArrayOfSize(expectedCount);
+    await expect($$(DATASET_ROW_SELECTOR)).toBeElementsArrayOfSize(expectedCount);
 });
 
 Then("the dataset {string} should be listed", async (datasetName: string) => {

--- a/e2e/step-definitions/search_page.steps.ts
+++ b/e2e/step-definitions/search_page.steps.ts
@@ -46,9 +46,12 @@ Then("the {string} component should have multiple rows shown", async (componentN
     } else {
         throw new Error(`Unknown component for rows: ${componentName}`);
     }
-    const rows = await $$(selector);
-    // Expect at least 2 rows.
-    expect(rows.length).toBeGreaterThan(1);
+    // Don't snapshot $$ into a plain array before checking: that defeats retrying,
+    // since results render asynchronously after the search resolves.
+    await browser.waitUntil(async () => (await $$(selector)).length > 1, {
+        timeout: 15000,
+        timeoutMsg: `expected more than 1 row for "${componentName}"`
+    });
 });
 
 // // Step: Click a result row modal button.

--- a/src/main/weaviateService.ts
+++ b/src/main/weaviateService.ts
@@ -24,7 +24,11 @@ export async function create_weaviate_database(storagePath: string) {
       host: '127.0.0.1',
       port: 9898,
       persistenceDataPath: path.join(storagePath, "weaviate_data"),
-      binaryPath: findWeaviate()
+      binaryPath: findWeaviate(),
+      // Without this, a single embedded node can wait indefinitely for raft to see
+      // enough peers before it elects a leader, surfacing as "leader not found" on
+      // any schema read/write shortly after startup.
+      env: { RAFT_BOOTSTRAP_EXPECT: '1' }
     });
     
     embedded_db = new EmbeddedDB(embeddedOptions);

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -46,7 +46,10 @@ export const config: WebdriverIO.Config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 10,
+    // Each spec file boots its own embedded Weaviate server; running specs concurrently
+    // starves them all of leader-election time, causing intermittent "leader not found"
+    // upload failures. Running serially avoids that contention.
+    maxInstances: 1,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -165,7 +168,9 @@ export const config: WebdriverIO.Config = {
         // <string> (expression) only execute the features or scenarios with tags matching the expression
         tagExpression: '',
         // <number> timeout for step definitions
-        timeout: 60000,
+        // Generous because the embedded Weaviate instance can take a while to finish
+        // starting up (raft leader election, first schema write) on a loaded machine.
+        timeout: 75000,
         // <boolean> Enable this config to treat undefined definitions as warnings.
         ignoreUndefinedDefinitions: false
     },


### PR DESCRIPTION
## Summary
Investigated the flaky wdio e2e suite and found it wasn't just test timing — there was a real, reproducible bug in the upload path plus a few test-only bugs compounding it:

- **Non-retrying `$$` snapshots**: `initial_application_view.steps.ts` / `search_page.steps.ts` resolved `$$(selector)` into a plain array *before* checking its length, which defeats webdriverio's built-in polling. Fixed by passing the lazy query directly to `expect()` / `browser.waitUntil`.
- **Redundant duplicate uploads**: `search-page.feature`'s `Background` re-uploaded `"Test Dataset 1"` before every scenario with no cleanup in between, guaranteeing a wasted, failing duplicate-name insert every time after the first. Implemented the previously-stubbed `"the metadata store is empty"` step and wired it into the Background.
- **Unserialized clicks**: the generic "component has been clicked" steps did a fixed pause instead of waiting for the actual async upload/search to finish, so the next step could kick off a second upload/search while the first was still running.
- **Embedded Weaviate leader election**: no `RAFT_BOOTSTRAP_EXPECT` meant the single-node raft group could take a while to elect a leader after startup, causing "leader not found" errors on uploads — which `uploadCsv()`'s error-cleanup path turns into a silently deleted dataset. This was the actual root cause behind most of the "flaky" failures, not just test timing.
- **Parallel spec files**: each spec file boots its own embedded Weaviate instance; running them concurrently (`maxInstances: 10`) starved each other of leader-election time. Capped to serial.

## Companion PRs
- jeremybmerrill/meaningfully-ui#5 — search button wasn't disabled for an empty query (found via the "disabled if no query" scenario only passing by accident)
- jeremybmerrill/meaningfully-core#4 — bounded retry on the transient Weaviate "leader not found" error, as a safety net alongside the `RAFT_BOOTSTRAP_EXPECT` fix in this PR

## Test plan
- [x] `npm run build` passes
- [x] Ran the full `WDIO_DEV=true npm run wdio` suite ~10 times; the deterministic failures above no longer occur
- [ ] Note: the very first upload after a fresh app launch can occasionally still exceed even the generous timeouts here if the machine is under heavy load (raft leader election + Weaviate startup) — flagged as a known, environment-dependent edge case rather than something further timeout-tuning should chase

🤖 Generated with [Claude Code](https://claude.com/claude-code)