### PR TITLE
Add lmStudioBaseURL to the Settings IPC surface

### DIFF
--- a/e2e/step-definitions/api-key-status.steps.ts
+++ b/e2e/step-definitions/api-key-status.steps.ts
@@ -15,6 +15,7 @@ Given("the settings store is empty", async () => {
             window.api.setSettings({ 
                 openAIKey: "", 
                 oLlamaBaseURL: "",
+                lmStudioBaseURL: "",
                 azureOpenAIKey: "",
                 azureOpenAIEndpoint: "",
                 azureOpenAIApiVersion: "",
@@ -35,6 +36,7 @@ Given("the setting store has an OpenAI API Key value", async () => {
             window.api.setSettings({ 
                 openAIKey: "sk-proj-meaningfullytesting-1234567890123456789012345678901234567890", 
                 oLlamaBaseURL: "",
+                lmStudioBaseURL: "",
                 azureOpenAIKey: "",
                 azureOpenAIEndpoint: "",
                 azureOpenAIApiVersion: "",

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -52,6 +52,7 @@ export interface DocumentSetMetadata {
 export interface Settings {
   openAIKey: string;
   oLlamaBaseURL: string;
+  lmStudioBaseURL: string;
   azureOpenAIKey: string;
   azureOpenAIEndpoint: string;
   azureOpenAIApiVersion: string;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,6 +84,7 @@ contextBridge.exposeInMainWorld('api', {
   getSettings: () => ipcRenderer.invoke('get-settings'),
   setSettings: (settings: {  openAIKey: string;
     oLlamaBaseURL: string;
+    lmStudioBaseURL: string;
     azureOpenAIKey: string;
     azureOpenAIEndpoint: string;
     azureOpenAIApiVersion: string;


### PR DESCRIPTION
## Summary
Companion to jeremybmerrill/meaningfully-core#6 (LM Studio provider support) and jeremybmerrill/meaningfully-ui#6 (LM Studio settings UI). This repo's `main`/`preload` layer is provider-agnostic (settings flow through as an opaque object), so the only changes needed here are:

- `preload/index.d.ts` / `preload/index.ts`: add `lmStudioBaseURL` to the hand-maintained `Settings` type copies exposed over the IPC contextBridge.
- `e2e/step-definitions/api-key-status.steps.ts`: reset `lmStudioBaseURL` alongside the other provider settings in the settings-reset test fixtures.

## Test plan
- [x] `npm run build:deps && npm run build` (builds `@meaningfully/core` and `@meaningfully/ui` from their sibling LM Studio branches, then typechecks + builds this app) — 0 errors
- [x] `WDIO_DEV=true npm run wdio run ./wdio.conf.ts -- --spec ./e2e/features/settings-page.feature` — 21/21 passing
- [x] Verified the built renderer bundle contains the "LM Studio" label and `lmstudio` provider value

🤖 Generated with [Claude Code](https://claude.com/claude-code)