### PR TITLE
add Hybrid search as "Sort Differently" button

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -104,12 +104,12 @@ app.whenReady().then(() => {
     }
   });
 
-  ipcMain.handle('search-document-set', async (_, params: { documentSetId: number, query: string, n_results: number, offset?: number, filters?: MetadataFilter[]}) => {
+  ipcMain.handle('search-document-set', async (_, params: { documentSetId: number, query: string, n_results: number, offset?: number, filters?: MetadataFilter[], searchMode?: 'semantic' | 'bm25' }) => {
     try {
-      return await docService.searchDocumentSet(params.documentSetId, params.query, params.n_results, params.filters, params.offset ?? 0);
+      return await docService.searchDocumentSet(params.documentSetId, params.query, params.n_results, params.filters, params.offset ?? 0, params.searchMode ?? 'semantic');
     } catch (error) {
-      console.error('Error searching document set:', error, params.documentSetId, params.query, params.n_results, params.offset, params.filters);
-      throw error;  
+      console.error('Error searching document set:', error, params.documentSetId, params.query, params.n_results, params.offset, params.filters, params.searchMode);
+      throw error;
     }
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -104,7 +104,7 @@ app.whenReady().then(() => {
     }
   });
 
-  ipcMain.handle('search-document-set', async (_, params: { documentSetId: number, query: string, n_results: number, offset?: number, filters?: MetadataFilter[], searchMode?: 'semantic' | 'bm25' }) => {
+  ipcMain.handle('search-document-set', async (_, params: { documentSetId: number, query: string, n_results: number, offset?: number, filters?: MetadataFilter[], searchMode?: 'semantic' | 'hybrid' }) => {
     try {
       return await docService.searchDocumentSet(params.documentSetId, params.query, params.n_results, params.filters, params.offset ?? 0, params.searchMode ?? 'semantic');
     } catch (error) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -108,7 +108,7 @@ declare global {
           operator: "==" | "in" | ">" | "<" | "!=" | ">=" | "<=" | "nin" | "any" | "all" | "text_match" | "contains" | "is_empty",
           value: any
         }[];
-        searchMode?: "semantic" | "bm25";
+        searchMode?: "semantic" | "hybrid";
       }) => Promise<SearchResponse>,
       getDocument(params: {
         documentSetId: number;

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -103,11 +103,12 @@ declare global {
         query: string;
         n_results: number;
         offset?: number;
-        filters?: { 
-          key: string, 
-          operator: "==" | "in" | ">" | "<" | "!=" | ">=" | "<=" | "nin" | "any" | "all" | "text_match" | "contains" | "is_empty", 
-          value: any 
+        filters?: {
+          key: string,
+          operator: "==" | "in" | ">" | "<" | "!=" | ">=" | "<=" | "nin" | "any" | "all" | "text_match" | "contains" | "is_empty",
+          value: any
         }[];
+        searchMode?: "semantic" | "bm25";
       }) => Promise<SearchResponse>,
       getDocument(params: {
         documentSetId: number;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,7 +74,7 @@ contextBridge.exposeInMainWorld('api', {
     n_results: number;
     offset?: number;
     filters?: Record<string, any>;
-    searchMode?: 'semantic' | 'bm25';
+    searchMode?: 'semantic' | 'hybrid';
   }) => ipcRenderer.invoke('search-document-set', params),
   
   getDocument: (params: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,6 +74,7 @@ contextBridge.exposeInMainWorld('api', {
     n_results: number;
     offset?: number;
     filters?: Record<string, any>;
+    searchMode?: 'semantic' | 'bm25';
   }) => ipcRenderer.invoke('search-document-set', params),
   
   getDocument: (params: {


### PR DESCRIPTION
I have long wanted to experiment with Hybrid search, which boosts semantic-results that exact-match keywords from the query. I've added this here as a "Sort Differently" button (to deemphasize the jargony terms BM25 and Hybrid Search); based on my thesis that semantic search is magic that often gives you what you're looking for (without you having to know how or why), "sort differently" is just a way to squeeze a little bit more juice from the lemon.

My hypothesis is that, for an exploratory use-case as in data journalism (versus an ecommerce one), vanilla semantic search works better than BM25 -- because it surfaces less-expected results, and users likely have already exhausted keyword search. But we'll see.

counterpart of https://github.com/jeremybmerrill/meaningfully-core/pull/8 and https://github.com/jeremybmerrill/meaningfully-ui/pull/11